### PR TITLE
Potential fix for code scanning alert no. 1: Type confusion through parameter tampering

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,12 @@ router.get("/mail/config-v1.1.xml", async (ctx) => {
 router.get("/email.mobileconfig", async (ctx) => {
 	let email = ctx.request.query.email;
 
-	if (!email) {
+	// Ensure email is a single string value, not an array, to avoid type confusion issues
+	if (Array.isArray(email)) {
+		email = email[0] || "";
+	}
+
+	if (!email || typeof email !== "string") {
 		ctx.status = 400;
 		return;
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/freifunkMUC/autodiscover-email-settings/security/code-scanning/1](https://github.com/freifunkMUC/autodiscover-email-settings/security/code-scanning/1)

In general, to fix this kind of issue you must validate the runtime type of user-controlled data before using methods that assume a specific type (here, string methods like `indexOf` and `split`). If the value is not of the expected type, reject the request or normalize it into a safe string representation before proceeding.

For this specific code, the best minimal fix is to ensure `email` is a single string. We can do this in two steps, right after retrieving it:

1. If `email` is an array (e.g., because multiple `email` parameters were sent), coerce it safely into a single string representation, such as by joining the elements with a comma, or more simply, by taking the first element as the intended email. Using the first element is less surprising and avoids combining potentially malicious fragments.
2. After normalization, verify that `email` is a non-empty string; if not, return HTTP 400 as the existing code already does for falsy values.

This avoids changing downstream logic and behavior, while eliminating the possibility that `indexOf` and `split` are invoked on an array. Concretely, in `index.js` around line 106, we will add a type check:

- If `Array.isArray(email)`, set `email = email[0] || ""`.
- Keep the existing `if (!email) { ... }` check so malformed requests are rejected.

No new imports or external libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
