### PR TITLE
Update repository URLs to freifunkMUC fork

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Some key notes before you open a PR:
 
 Also, if you're new here
 
-- Contribution Guide => https://github.com/Monogramm/autodiscover-email-settings/blob/master/CONTRIBUTING.md
+- Contribution Guide => https://github.com/freifunkMUC/autodiscover-email-settings/blob/master/CONTRIBUTING.md
 
 -->
 

--- a/views/index.html
+++ b/views/index.html
@@ -278,7 +278,7 @@
                     It provides IMAP/POP/SMTP/LDAP Autodiscover capabilities on Microsoft Outlook/Apple Mail, Autoconfig
                     capabilities for Thunderbird, and Configuration Profiles for iOS/Apple Mail.
                 </p>
-                <p><a class="btn btn-primary btn-lg" href="https://github.com/Monogramm/autodiscover-email-settings"
+                <p><a class="btn btn-primary btn-lg" href="https://github.com/freifunkMUC/autodiscover-email-settings"
                         target="_blank" role="button">Learn more &raquo</a></p>
             </div>
         </div>


### PR DESCRIPTION
This PR updates the repository URLs pointing to the original Monogramm repository to this fork.

It annoyed me a bit that the *Learn more* button pointed at the wrong URL; also updated the PR template whilst updating the former one.