### PR TITLE
Fix protocol defaults blocking opt-out, and restore the requested response schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,33 +50,75 @@ function findChild(name, children, def = null) {
 	return def;
 }
 
-function extractEmailFromXml(raw) {
+const RESPONSE_SCHEMA_DEFAULT = "http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006";
+
+// Outlook asks for a specific response schema and expects the answer in that schema.
+// The value is echoed into an xmlns attribute, so only the schemas Outlook actually
+// asks for are accepted; anything else falls back to the default instead of being
+// reflected back to the client.
+const RESPONSE_SCHEMA_ALLOWED = /^https?:\/\/schemas\.microsoft\.com\/exchange\/autodiscover\/(?:outlook\/)?responseschema\/[0-9]{4}[a-z]?$/i;
+
+function decodeXmlEntities(value) {
+	return value
+		.replace(/&lt;/gi, "<")
+		.replace(/&gt;/gi, ">")
+		.replace(/&quot;/gi, "\"")
+		.replace(/&apos;/gi, "'")
+		.replace(/&#x([0-9a-f]+);/gi, (match, hex) => {
+			const code = parseInt(hex, 16);
+			return code >= 0 && code <= 0x10FFFF ? String.fromCodePoint(code) : "";
+		})
+		.replace(/&#([0-9]+);/g, (match, dec) => {
+			const code = parseInt(dec, 10);
+			return code >= 0 && code <= 0x10FFFF ? String.fromCodePoint(code) : "";
+		})
+		// &amp; is decoded last, otherwise "&amp;lt;" would turn into "<"
+		.replace(/&amp;/gi, "&");
+}
+
+// Reads the text of the first matching element out of the raw request body.
+// Entities are decoded here: without it the value keeps its XML encoding and gets
+// escaped a second time on output ("a&b" comes back as "a&amp;amp;b").
+function extractTagFromXml(raw, tag) {
 	if (!raw) return null;
-	const m = raw.match(/<EMailAddress>([^<]+)<\/EMailAddress>/i);
-	return m ? m[1] : null;
+	const match = raw.match(new RegExp("<(?:[A-Za-z0-9_.-]+:)?" + tag + "(?:\\s[^>]*)?>([^<]*)<\\/", "i"));
+	if (!match) return null;
+	const value = decodeXmlEntities(match[1]).trim();
+	return value === "" ? null : value;
 }
 
 // Microsoft Outlook / Apple Mail
 async function autodiscover(ctx) {
 	// Try to use parsed body if available, otherwise fallback to raw XML extraction
 	let email = null;
+	let xmlns = null;
 	if (ctx.request.body && typeof ctx.request.body === 'object') {
 		const request = ctx.request.body.root && ctx.request.body.root.children ?
 			findChild("Request", ctx.request.body.root.children) : null;
 		const schema = request !== null ? findChild("AcceptableResponseSchema", request.children) : null;
-		const xmlns = schema !== null ? schema.content : "http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006";
+		if (schema !== null && schema.content) {
+			xmlns = schema.content;
+		}
 
 		let emailNode = request !== null ? findChild("EMailAddress", request.children) : null;
 		if (emailNode && emailNode.content) {
 			email = emailNode.content;
 		}
-
-		ctx.state._xmlns = xmlns;
 	}
 
+	// The parsed-body branch above only matches the shape of the previous XML parser.
+	// The current one yields a different tree, so in practice the raw body is what
+	// carries both values — the requested schema included, which was otherwise lost
+	// and every client silently answered in the generic schema.
+	const raw = ctx.request.rawBody || (typeof ctx.request.body === 'string' ? ctx.request.body : null);
 	if (!email) {
-		const raw = ctx.request.rawBody || (typeof ctx.request.body === 'string' ? ctx.request.body : null);
-		email = extractEmailFromXml(raw);
+		email = extractTagFromXml(raw, "EMailAddress");
+	}
+	if (!xmlns) {
+		xmlns = extractTagFromXml(raw, "AcceptableResponseSchema");
+	}
+	if (!xmlns || !RESPONSE_SCHEMA_ALLOWED.test(xmlns)) {
+		xmlns = RESPONSE_SCHEMA_DEFAULT;
 	}
 
 	let username;
@@ -103,7 +145,7 @@ async function autodiscover(ctx) {
 	const smtpssl = settings.smtp.socket === "SSL" ? "on" : "off";
 
 	await ctx.render('autodiscover.xml', Object.assign({}, settings, {
-		schema: ctx.state._xmlns || "http://schemas.microsoft.com/exchange/autodiscover/responseschema/2006",
+		schema: xmlns,
 		email,
 		username,
 		domain,

--- a/settings.js
+++ b/settings.js
@@ -1,25 +1,41 @@
+// Environment parsing.
+//
+// Three states are distinguished, not two:
+//   variable unset      -> use the default (the fork's intent: DOMAIN alone is enough);
+//   variable set to ""  -> the protocol is DISABLED, its block is left out of the response;
+//   variable set        -> use the given value.
+//
+// Without the empty-string case an unwanted protocol could not be turned off at all:
+// `||` treats "" as falsy and falls back to the default, so POP_HOST="" still advertised
+// pop.<domain> — a server that need not exist. Clients were then offered a host that
+// fails to resolve or refuses the connection.
+const envOr = (value, fallback) =>
+	value === undefined ? fallback : (value === '' ? undefined : value);
+
+const domain = envOr(process.env.DOMAIN, 'example.com');
+
 module.exports = {
 	info: {
- 		name: process.env.COMPANY_NAME || process.env.DOMAIN || 'Example',
- 		url: process.env.SUPPORT_URL || (process.env.DOMAIN ? `https://${process.env.DOMAIN}` : '')
+		name: envOr(process.env.COMPANY_NAME, domain || 'Example'),
+		url: envOr(process.env.SUPPORT_URL, domain ? `https://${domain}` : '')
 	},
-	domain: process.env.DOMAIN || 'example.com',
+	domain: domain,
 
 	// sensible defaults derived from domain when specific env vars are not provided
 	imap: {
-		host: process.env.IMAP_HOST || `imap.${process.env.DOMAIN || 'example.com'}`,
-		port: process.env.IMAP_PORT || '993',
-		socket: process.env.IMAP_SOCKET || 'SSL'
+		host: envOr(process.env.IMAP_HOST, `imap.${domain || 'example.com'}`),
+		port: envOr(process.env.IMAP_PORT, '993'),
+		socket: envOr(process.env.IMAP_SOCKET, 'SSL')
 	},
 	pop: {
-		host: process.env.POP_HOST || `pop.${process.env.DOMAIN || 'example.com'}`,
-		port: process.env.POP_PORT || '995',
-		socket: process.env.POP_SOCKET || 'SSL'
+		host: envOr(process.env.POP_HOST, `pop.${domain || 'example.com'}`),
+		port: envOr(process.env.POP_PORT, '995'),
+		socket: envOr(process.env.POP_SOCKET, 'SSL')
 	},
 	smtp: {
-		host: process.env.SMTP_HOST || `smtp.${process.env.DOMAIN || 'example.com'}`,
-		port: process.env.SMTP_PORT || '587',
-		socket: process.env.SMTP_SOCKET || 'STARTTLS'
+		host: envOr(process.env.SMTP_HOST, `smtp.${domain || 'example.com'}`),
+		port: envOr(process.env.SMTP_PORT, '587'),
+		socket: envOr(process.env.SMTP_SOCKET, 'STARTTLS')
 	},
 	mobilesync: {
 		url: process.env.MOBILESYNC_URL,


### PR DESCRIPTION
Thanks for keeping this fork alive — it is the only maintained one, and the modernization to koa 3 / non-root / pinned base is exactly what the ecosystem needed.

While putting it into production in front of four domains I hit three defects and verified each against a running instance. Two commits, independent — feel free to cherry-pick either.

### 1. An empty env var cannot disable a protocol (`settings.js`)

The defaults for imap/pop/smtp use `||`, which treats `""` as falsy, so an unwanted protocol cannot be switched off at all:

| `POP_HOST` | resulting `<hostname>` |
|---|---|
| unset | `pop.<domain>` |
| `""` | `pop.<domain>` — the default comes back |
| `" "` | `<hostname> </hostname>` |
| `"0"` / `"false"` / `"none"` | the literal string |

My mail host runs IMAP and SMTP only (`ENABLE_POP3=0`, dovecot listens on 143/993 and nothing on 110/995). Every client was therefore offered a POP3 server that does not resolve, and there was no way to remove it short of patching the file.

The commit keeps the feature and adds the missing third state: unset → default, `""` → protocol disabled, value → use it.

### 2. `AcceptableResponseSchema` is never echoed back (`index.js`)

The parsed-body branch matches the tree shape of the *previous* XML parser; `koa-xml-body` produces a different one, so the branch never fires and the raw-body regex — which only looked for `EMailAddress` — does the work. Outlook asking for `.../outlook/responseschema/2006a` was always answered in the generic `.../responseschema/2006`.

Given the open upstream report that Outlook cannot complete autodiscover, this may be worth checking against a real Outlook.

### 3. XML entities are escaped twice

Same fallback returns the text still encoded, so it is escaped again on output: `a&b@example.com` comes back as `a&amp;amp;b@example.com`.

Both are fixed by one helper that decodes entities (`&amp;` last so decoded text is not decoded twice, numeric references range-checked so a malformed one cannot throw). Since the schema lands in an `xmlns` attribute, only the schemas Outlook actually asks for are accepted; anything else falls back to the default instead of being reflected back.

### Verification

Run against the built image with a real deployment's environment:

- Thunderbird endpoint output is byte-identical to the old (pre-fork) container once POP is disabled
- `responseschema/2006a` requested → answered in `2006a`
- `http://evil.example.com/pwn` requested → falls back to the default
- `a&b@example.com` → `a&amp;b@example.com`
- existing autoescaping unaffected: `<inj>@example.com` → `&lt;inj&gt;@example.com`